### PR TITLE
fixes register native routine note

### DIFF
--- a/src/dummy.c
+++ b/src/dummy.c
@@ -1,0 +1,9 @@
+/* dummy file with no function but creates symbols to pass R CMD check */
+
+extern void R_registerRoutines();
+extern void R_useDynamicSymbols();
+
+void dummy_() {
+  R_registerRoutines();
+  R_useDynamicSymbols();
+}


### PR DESCRIPTION
This solution is borrowed from https://github.com/s-u/krb5/blob/master/src/dummy.c

It fixes the "register native routine" note in https://github.com/elong0527/simuCCP/issues/2#issuecomment-804375713.