### PR TITLE
fixes vignette check issue in #2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,4 +4,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.github$
-^vignettes$

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-inst/doc
 .Rproj.user
 .Rhistory
 .RData

--- a/R/BiCopCDF.R
+++ b/R/BiCopCDF.R
@@ -13,9 +13,9 @@ BiCopCDF <- function(u1, u2, family, par, par2 = 0) {
   if (!(family %in% c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 16, 17, 18, 19, 20, 23, 24, 26, 27, 28,
                       29, 30, 33, 34, 36, 37, 38, 39, 40)))
     stop("Copula family not implemented.")
-  if (c(2, 7, 8, 9, 10, 17, 18, 19, 20, 27, 28, 29, 30, 37, 38, 39, 40) %in% family && par2 == 0)
+  if (any(c(2, 7, 8, 9, 10, 17, 18, 19, 20, 27, 28, 29, 30, 37, 38, 39, 40) %in% family) && par2 == 0)
     stop("For t-, BB1, BB6, BB7 and BB8 copulas, 'par2' must be set.")
-  if (c(1, 3, 4, 5, 6, 13, 14, 16, 23, 24, 26, 33, 34, 36) %in% family && length(par) < 1)
+  if (any(c(1, 3, 4, 5, 6, 13, 14, 16, 23, 24, 26, 33, 34, 36) %in% family) && length(par) < 1)
     stop("'par' not set.")
 
   if ((family == 1 || family == 2) && abs(par[1]) >= 1)

--- a/R/CDVineSim.R
+++ b/R/CDVineSim.R
@@ -30,8 +30,7 @@ CDVineSim <- function(N, family, par, par2 = rep(0, length(family)), type) {
 
     if (length(par) < dd)
       stop("Length of 'par' has to be d*(d-1)/2.")
-    if (c(2, 7, 8, 9, 10, 17, 18, 19, 20, 27, 28, 29, 30, 37, 38, 39, 40) %in% family && length(par2) !=
-        dd)
+    if (any(c(2, 7, 8, 9, 10, 17, 18, 19, 20, 27, 28, 29, 30, 37, 38, 39, 40) %in% family) && length(par2) != dd)
       stop("Length of 'par2' has to be d*(d-1)/2 if t, BB1, BB6, BB7 or BB8 copulas are used.")
     if (length(family) != dd)
       stop("Length of 'family' has to be d*(d-1)/2.")


### PR DESCRIPTION
- Use `any()` to reduce the vector returns from `%in%` calls in CDVine functions
- Restore checking vignette rebuild by removing the folder from `.Rbuildignore`